### PR TITLE
Feature/boundary hiding macros

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
    ["snapshots" :clojars]]
 
   :dependencies
-  [[org.clojure/clojure "1.9.0-RC2"]
-   [org.clojure/tools.deps.alpha "0.2.190"]
+  [[org.clojure/clojure "1.9.0"]
+   [org.clojure/tools.deps.alpha "0.2.196"]
    [org.projectodd.shimdandy/shimdandy-api "1.2.0"]
    [org.xeustechnologies/jcl-core "2.8"]])

--- a/resources/shims.clj
+++ b/resources/shims.clj
@@ -23,3 +23,10 @@
                   (if (= 'exit form) request-exit form))))
             (catch Exception e (some-> (.getMessage e) println))
             (finally (println "=== Finished ==="))))))))
+
+
+(defmulti serialize class)
+(defmethod serialize :default [code] (pr-str code))
+
+(defmulti deserialize class)
+(defmethod deserialize :default [code] (read-string code))

--- a/resources/shims.clj
+++ b/resources/shims.clj
@@ -1,14 +1,13 @@
 (ns clj-embed.shims
-  (:require [clojure.core :as core]
-            [clojure.main :as main]))
+  (:require [clojure.main :as main]))
 
 
-(defn load-string [s]
-  (core/load-string s))
+(defn my-load-string [s]
+  (load-string s))
 
 (defn piped-load-string [input output error s]
   (binding [*out* output *err* error *in* input]
-    (load-string s)))
+    (my-load-string s)))
 
 (defn start-repl-session [input output error]
   (.start
@@ -24,9 +23,12 @@
             (catch Exception e (some-> (.getMessage e) println))
             (finally (println "=== Finished ==="))))))))
 
-
 (defmulti serialize class)
-(defmethod serialize :default [code] (pr-str code))
+
+(defmethod serialize :default
+  [code] (pr-str code))
 
 (defmulti deserialize class)
-(defmethod deserialize :default [code] (read-string code))
+
+(defmethod deserialize :default
+  [code] (read-string code))

--- a/test/clj_embed/core_test.clj
+++ b/test/clj_embed/core_test.clj
@@ -12,9 +12,9 @@
   (testing "create a namespace in one place and show it's not in the root or in another."
     (let [r1 (new-runtime) r2 (new-runtime)]
       (try
-        (with-runtime r1 (ns clj-embed.my-test-ns))
-        (let [r1-namespaces   (with-runtime r1 (into #{} (map #(name (.getName %)) (all-ns))))
-              r2-namespaces   (with-runtime r2 (into #{} (map #(name (.getName %)) (all-ns))))
+        (exec-with-runtime r1 (ns clj-embed.my-test-ns))
+        (let [r1-namespaces   (exec-with-runtime r1 (into #{} (map #(name (.getName %)) (all-ns))))
+              r2-namespaces   (exec-with-runtime r2 (into #{} (map #(name (.getName %)) (all-ns))))
               root-namespaces (into #{} (map #(name (.getName %)) (all-ns)))]
           (is (contains? r1-namespaces "clj-embed.my-test-ns"))
           (is (not (contains? r2-namespaces "clj-embed.my-test-ns")))
@@ -28,8 +28,8 @@
     (let [[h1 h2]
           (let [r (new-runtime)]
             (try
-              [(with-runtime r (.hashCode RT))
-               (with-runtime r (.hashCode RT))]
+              [(exec-with-runtime r (.hashCode RT))
+               (exec-with-runtime r (.hashCode RT))]
               (finally
                 (close-runtime! r))))]
       (is (= h1 h2))))


### PR DESCRIPTION
This crawls the serialized code for any non-serializable object references and then builds a lookup table of the reader representation of the object -> the object reference. This lookup table is then passed to the runtime and used by the runtime to realize the references.